### PR TITLE
Add dynamic PDF iframe autosizing

### DIFF
--- a/css/pages.css
+++ b/css/pages.css
@@ -168,10 +168,19 @@
 /* PDF */
 .pdf-frame {
   width: clamp(var(--media-w-min), var(--media-w-vw), var(--pdf-w-max));
-  height: var(--pdf-h);
+  height: auto;
+  max-height: var(--pdf-h);
   border: 1px solid var(--hair);
   border-radius: 12px;
   background: #000;
+}
+
+/*
+ * When JavaScript can't sniff the PDF's aspect ratio we retain the legacy
+ * fixed height so embeds remain readable even without autosizing support.
+ */
+.pdf-frame:not([data-pdf-aspect]) {
+  height: var(--pdf-h);
 }
 
 /* Video */


### PR DESCRIPTION
## Summary
- tag rendered PDF iframes with their source URL and schedule autosizing during page render
- add a cached aspect ratio sniffer with shared resize handling to size PDF embeds dynamically
- update PDF frame styling to prefer inline heights while keeping a legacy fallback when autosizing fails

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e00403d17c83239376b51a251dbe3f